### PR TITLE
Added /all endpoint with search aggregation from different sources

### DIFF
--- a/src/main/java/co/edu/javeriana/dsbp/proyecto/controllers/RepositoryController.java
+++ b/src/main/java/co/edu/javeriana/dsbp/proyecto/controllers/RepositoryController.java
@@ -23,9 +23,14 @@ public class RepositoryController {
 	public List<Article> ebiSearch(@RequestParam String query) {
 		return producerTemplate.requestBody("direct:ebi-proxy", query, List.class);
 	}
+
+	@GetMapping("/all")
+	public List<Article> search(@RequestParam String query) {
+		return producerTemplate.requestBody("direct:search-articles-service", query, List.class);
+	}
 	
-	@RequestMapping("/")
-	public ArrayList<Article> search(@RequestBody ArrayList<String> keywords) {
+	@RequestMapping("/scope")
+	public ArrayList<Article> scopeSearch(@RequestBody ArrayList<String> keywords) {
 		ArrayList<Article> returnable = new ArrayList<Article>();
 		returnable.addAll(scopusRepository.search(keywords));
 		return returnable;

--- a/src/main/java/co/edu/javeriana/dsbp/proyecto/integration/Routes.java
+++ b/src/main/java/co/edu/javeriana/dsbp/proyecto/integration/Routes.java
@@ -1,5 +1,6 @@
 package co.edu.javeriana.dsbp.proyecto.integration;
 
+import co.edu.javeriana.dsbp.proyecto.integration.aggregators.SourceArticlesAggregator;
 import co.edu.javeriana.dsbp.proyecto.model.ebi.ResponseWrapper;
 import co.edu.javeriana.dsbp.proyecto.utils.Converter;
 import org.apache.camel.Exchange;
@@ -17,16 +18,30 @@ public class Routes extends RouteBuilder {
         df.setUnmarshalType(ResponseWrapper.class);
 
         from("direct:ebi-proxy")
-            .setProperty("query", simple("${body}"))
-            .setBody(constant(null))
-            .removeHeaders("*")
-            .setHeader(Exchange.HTTP_METHOD, constant("GET"))
-            .setHeader(Exchange.HTTP_QUERY, simple("query=${exchangeProperty[query]}"))
-            .to("https://www.ebi.ac.uk/europepmc/webservices/rest/search")
-            .convertBodyTo(String.class)
-            .log(LoggingLevel.DEBUG, "Antes del unmarshal ${body}")
-            .unmarshal(df)
-            .bean(Converter.class)
-            .log(LoggingLevel.DEBUG, "Despues del unmarshal ${body}");
+                .id("ebiProxyRoute")
+                .setProperty("query", simple("${body}"))
+                .setBody(constant(null))
+                .removeHeaders("*")
+                .setHeader(Exchange.HTTP_METHOD, constant("GET"))
+                .setHeader(Exchange.HTTP_QUERY, simple("query=${exchangeProperty[query]}"))
+                .log(LoggingLevel.INFO, "Searching articles in ebi")
+                .to("https://www.ebi.ac.uk/europepmc/webservices/rest/search")
+                .convertBodyTo(String.class)
+                .log(LoggingLevel.DEBUG, "Antes del unmarshal ${body}")
+                .unmarshal(df)
+                .bean(Converter.class)
+                .log(LoggingLevel.DEBUG, "Despues del unmarshal ${body}");
+
+        from("direct:scope-proxy")
+                .id("scopeProxyRoute")
+                .log(LoggingLevel.INFO, "Searching articles in Scope")
+                .process("scopeServiceProcessor");
+
+        from("direct:search-articles-service")
+                .id("searchArticleService")
+                .multicast(new SourceArticlesAggregator())
+                    .parallelProcessing()
+                    .to("direct:ebi-proxy", "direct:scope-proxy")
+                .end();
     }
 }

--- a/src/main/java/co/edu/javeriana/dsbp/proyecto/integration/aggregators/SourceArticlesAggregator.java
+++ b/src/main/java/co/edu/javeriana/dsbp/proyecto/integration/aggregators/SourceArticlesAggregator.java
@@ -1,0 +1,27 @@
+package co.edu.javeriana.dsbp.proyecto.integration.aggregators;
+
+import co.edu.javeriana.dsbp.proyecto.model.Article;
+import org.apache.camel.Exchange;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SourceArticlesAggregator implements org.apache.camel.AggregationStrategy {
+    @Override
+    public Exchange aggregate(Exchange oldExchange, Exchange newExchange) {
+        List<Article> articles;
+
+        if (oldExchange == null) {
+            articles = new ArrayList<>();
+        } else {
+            articles = oldExchange.getIn().getBody(ArrayList.class);
+        }
+
+        List<Article> newArticles = newExchange.getIn().getBody(ArrayList.class);
+
+        articles.addAll(newArticles);
+
+        newExchange.getIn().setBody(articles);
+        return newExchange;
+    }
+}

--- a/src/main/java/co/edu/javeriana/dsbp/proyecto/integration/processors/ScopeServiceProcessor.java
+++ b/src/main/java/co/edu/javeriana/dsbp/proyecto/integration/processors/ScopeServiceProcessor.java
@@ -1,0 +1,26 @@
+package co.edu.javeriana.dsbp.proyecto.integration.processors;
+
+import co.edu.javeriana.dsbp.proyecto.model.Article;
+import co.edu.javeriana.dsbp.proyecto.repository.WebServiceRepository;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+public class ScopeServiceProcessor implements Processor {
+
+    @Autowired
+    WebServiceRepository scopusRepository;
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        String searchTerms = exchange.getIn().getBody(String.class);
+        List<String> keys = Arrays.asList(searchTerms.split("\\s"));
+        List<Article> articles = scopusRepository.search(keys);
+        exchange.getIn().setBody(articles);
+    }
+}

--- a/src/main/java/co/edu/javeriana/dsbp/proyecto/model/ebi/BookOrReportDetails.java
+++ b/src/main/java/co/edu/javeriana/dsbp/proyecto/model/ebi/BookOrReportDetails.java
@@ -3,6 +3,7 @@ package co.edu.javeriana.dsbp.proyecto.model.ebi;
 public class BookOrReportDetails {
     private String publisher;
     private int yearOfPublication;
+    private String comprisingTitle;
 
     public String getPublisher() {
         return publisher;
@@ -18,5 +19,13 @@ public class BookOrReportDetails {
 
     public void setYearOfPublication(int yearOfPublication) {
         this.yearOfPublication = yearOfPublication;
+    }
+
+    public String getComprisingTitle() {
+        return comprisingTitle;
+    }
+
+    public void setComprisingTitle(String comprisingTitle) {
+        this.comprisingTitle = comprisingTitle;
     }
 }

--- a/src/main/java/co/edu/javeriana/dsbp/proyecto/repository/WebServiceRepository.java
+++ b/src/main/java/co/edu/javeriana/dsbp/proyecto/repository/WebServiceRepository.java
@@ -1,9 +1,11 @@
 package co.edu.javeriana.dsbp.proyecto.repository;
 
-import java.util.ArrayList;
+import java.util.List;
 
 import co.edu.javeriana.dsbp.proyecto.model.Article;
+import org.springframework.stereotype.Service;
 
+@Service
 public interface WebServiceRepository {
-	public ArrayList<Article> search(ArrayList<String> keywords);
+	List<Article> search(List<String> keywords);
 }

--- a/src/main/java/co/edu/javeriana/dsbp/proyecto/repository/impl/ScopusRepository.java
+++ b/src/main/java/co/edu/javeriana/dsbp/proyecto/repository/impl/ScopusRepository.java
@@ -5,6 +5,8 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.simple.JSONArray;
@@ -20,7 +22,7 @@ public class ScopusRepository implements WebServiceRepository {
     private static final Logger logger = LogManager.getLogger(ScopusRepository.class);
 	
 	@Override
-	public ArrayList<Article> search(ArrayList<String> keywords) {
+	public List<Article> search(List<String> keywords) {
 		if(keywords == null || keywords.size() == 0) return new ArrayList<Article>();
 		
 		String queryFilter = String.join(",", keywords);


### PR DESCRIPTION
# Detalle del cambio

Se implementó nuevo endpoint GET /all con la agregación de las diferentes fuentes de artículos (ebi y Scopus a la fecha). Se modificó el endpoint anterior / a /scopus.

## Pruebas realizadas

* Paso1: Se realiza petición HTTP al endpoint /all?query=fever. Se evidencia la agregación de diferentes fuentes bibliográficas.

![image](https://user-images.githubusercontent.com/7977317/94945247-0760e080-04a0-11eb-8dd6-7de5882167c9.png)

